### PR TITLE
Broken link to recovery repo in 'Recommendations'

### DIFF
--- a/_pages/recommendations.html
+++ b/_pages/recommendations.html
@@ -36,7 +36,7 @@ permalink: /recommendations/
             </li>
             <li>To continuously develop and improve online fleet <b>monitoring</b> tools like <a href="https://fleetmonitoring.euro-argo.eu">https://fleetmonitoring.euro-argo.eu</a> (eg: to include more information on sensor performance).</li>
             <li>The user community requests that NKE extend the <b>mission planning tool</b> APMT Profiler GUI (dedicated to the Provor CTS5) to the Arvor. This tool allows the user to design a configuration and receive information about the expected lifetime of the float, data telemetry estimates, etc., as a function of sensor payload and cycle configurations.</li>
-            <li>To <b>improve recovery methods</b> of floats. This workshop resulted in the creation of a working group on this topic at <a href="github.com/euroargodev/recovery">github.com/euroargodev/recovery</a>.</li>
+            <li>To <b>improve recovery methods</b> of floats. This workshop resulted in the creation of a working group on this topic at <a href="https://github.com/euroargodev/recovery">https://github.com/euroargodev/recovery</a>.</li>
         </ol>
         <p class="subtitle highlight">By the organizing committee:</p>
             {% include committee.html %}


### PR DESCRIPTION
The link to the recovery repository was not working properly, at least on my station it was trying to access "https://euroargodev.github.io/techworkshop/recommendations/github.com/euroargodev/recovery". I added 'https://' to fix, I also added it to the written link for consistency.